### PR TITLE
Add initial gradle support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,7 @@ repositories {
     maven(url = "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide-plugin-dependencies")
     maven(url = "https://www.jetbrains.com/intellij-repository/releases")
     maven(url = "https://cache-redirector.jetbrains.com/intellij-third-party-dependencies")
+    maven(url = "https://repo.gradle.org/gradle/libs-releases")
 }
 
 dependencies {
@@ -39,6 +40,7 @@ dependencies {
 
     implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:0.24.0")
     implementation("com.h2database:h2:2.3.232")
+    implementation("org.gradle:gradle-tooling-api:8.12")
 
     testImplementation(platform("org.junit:junit-bom:5.12.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/app/src/main/kotlin/org/kotlinlsp/buildsystem/Gradle.kt
+++ b/app/src/main/kotlin/org/kotlinlsp/buildsystem/Gradle.kt
@@ -14,7 +14,6 @@ import org.kotlinlsp.analysis.services.modules.LibraryModule
 import org.kotlinlsp.analysis.services.modules.SourceModule
 import org.kotlinlsp.common.debug
 import java.io.File
-import java.nio.file.Path
 
 class GradleBuildSystem(
     private val project: MockProject,
@@ -39,11 +38,11 @@ class GradleBuildSystem(
         val ideaProject = model.get()
 
         val jvmTarget = checkNotNull(JvmTarget.fromString(ideaProject.jdkName)) { "Unknown jdk target" }
-        val jdkModule = getJdkHomePathFromSystemProperty()?.let { jdkHome ->
+        val jdkModule = ideaProject.javaLanguageSettings?.jdk?.let { jdk ->
             LibraryModule(
                 appEnvironment = appEnvironment,
                 mockProject = project,
-                roots = listOf(jdkHome),
+                roots = listOf(jdk.javaHome.toPath()),
                 javaVersion = jvmTarget,
                 isJdk = true,
                 name = "JDK ${jvmTarget.description}"
@@ -83,12 +82,4 @@ class GradleBuildSystem(
         val rootModule = modules.last()
         return rootModule to ""
     }
-}
-
-private fun getJdkHomePathFromSystemProperty(): Path? {
-    val javaHome = File(System.getProperty("java.home"))
-    if (!javaHome.exists()) {
-        return null
-    }
-    return javaHome.toPath()
 }

--- a/app/src/main/kotlin/org/kotlinlsp/buildsystem/Gradle.kt
+++ b/app/src/main/kotlin/org/kotlinlsp/buildsystem/Gradle.kt
@@ -22,7 +22,10 @@ class GradleBuildSystem(
     private val appEnvironment: KotlinCoreApplicationEnvironment,
     private val rootFolder: String
 ) : BuildSystem {
-    override val markerFiles: List<String> = listOf("$rootFolder/build.gradle", "$rootFolder/build.gradle.kts")
+    override val markerFiles: List<String> = listOf(
+        "$rootFolder/build.gradle", "$rootFolder/build.gradle.kts",
+        "$rootFolder/settings.gradle", "$rootFolder/settings.gradle.kts",
+    )
 
     @OptIn(KaImplementationDetail::class)
     override fun resolveRootModuleIfNeeded(cachedVersion: String?): Pair<KaModule, String>? {

--- a/app/src/main/kotlin/org/kotlinlsp/buildsystem/Gradle.kt
+++ b/app/src/main/kotlin/org/kotlinlsp/buildsystem/Gradle.kt
@@ -15,7 +15,6 @@ import org.kotlinlsp.analysis.services.modules.SourceModule
 import org.kotlinlsp.common.debug
 import java.io.File
 import java.nio.file.Path
-import kotlin.io.path.Path
 
 class GradleBuildSystem(
     private val project: MockProject,
@@ -51,15 +50,6 @@ class GradleBuildSystem(
             )
         }
 
-        val kotlinStdlib = LibraryModule(
-            appEnvironment = appEnvironment,
-            mockProject = project,
-            name = "Kotlin stdlib",
-            javaVersion = jvmTarget,
-            roots = listOf(getKotlinJvmStdlibJarPath()),
-        )
-
-
         val modules = ideaProject.modules.map { module ->
             val dependencies = module
                 .dependencies
@@ -74,12 +64,10 @@ class GradleBuildSystem(
                     )
                 }
 
-
-            val allDependencies = mutableListOf<KaModule>(kotlinStdlib)
+            val allDependencies: MutableList<KaModule> = dependencies.toMutableList()
             if (jdkModule != null) {
                 allDependencies.add(jdkModule)
             }
-            allDependencies.addAll(dependencies)
 
             SourceModule(
                 mockProject = project,
@@ -103,16 +91,4 @@ private fun getJdkHomePathFromSystemProperty(): Path? {
         return null
     }
     return javaHome.toPath()
-}
-
-internal fun getKotlinJvmStdlibJarPath(): Path {
-    return Path(lazyKotlinJvmStdlibJar)
-}
-
-private val lazyKotlinJvmStdlibJar by lazy {
-    ClassLoader.getSystemResource("kotlin/jvm/Strictfp.class")
-        ?.file
-        ?.replace("file:", "")
-        ?.replaceAfter(".jar", "")
-        ?: error("Unable to find Kotlin's JVM stdlib jar.")
 }

--- a/app/src/main/kotlin/org/kotlinlsp/buildsystem/Gradle.kt
+++ b/app/src/main/kotlin/org/kotlinlsp/buildsystem/Gradle.kt
@@ -1,13 +1,115 @@
 package org.kotlinlsp.buildsystem
 
+import com.intellij.mock.MockProject
+import org.gradle.tooling.GradleConnector
+import org.gradle.tooling.events.OperationType
+import org.gradle.tooling.model.idea.IdeaProject
+import org.gradle.tooling.model.idea.IdeaSingleEntryLibraryDependency
+import org.jetbrains.kotlin.analysis.api.KaImplementationDetail
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaModule
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreApplicationEnvironment
+import org.jetbrains.kotlin.config.JvmTarget
+import org.jetbrains.kotlin.config.LanguageVersion
+import org.kotlinlsp.analysis.services.modules.LibraryModule
+import org.kotlinlsp.analysis.services.modules.SourceModule
+import org.kotlinlsp.common.debug
+import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.Path
 
-class GradleBuildSystem: BuildSystem {
-    override val markerFiles: List<String>
-        get() = listOf()    // TODO
+class GradleBuildSystem(
+    private val project: MockProject,
+    private val appEnvironment: KotlinCoreApplicationEnvironment,
+    private val rootFolder: String
+) : BuildSystem {
+    override val markerFiles: List<String> = listOf("$rootFolder/build.gradle", "$rootFolder/build.gradle.kts")
 
+    @OptIn(KaImplementationDetail::class)
     override fun resolveRootModuleIfNeeded(cachedVersion: String?): Pair<KaModule, String>? {
-        // TODO
+        val connection = GradleConnector.newConnector()
+            .forProjectDirectory(File(rootFolder))
+            .connect()
+
+        val model = connection.model(IdeaProject::class.java)
+
+        model.addProgressListener({ debug("[GRADLE] ${it.displayName}") }, OperationType.PROJECT_CONFIGURATION)
+
+        val ideaProject = model.get()
+
+        val jvmTarget = checkNotNull(JvmTarget.fromString(ideaProject.jdkName)) { "Unknown jdk target" }
+        val jdkModule = getJdkHomePathFromSystemProperty()?.let { jdkHome ->
+            LibraryModule(
+                appEnvironment = appEnvironment,
+                mockProject = project,
+                roots = listOf(jdkHome),
+                javaVersion = jvmTarget,
+                isJdk = true,
+                name = "JDK ${jvmTarget.description}"
+            )
+        }
+
+        val kotlinStdlib = LibraryModule(
+            appEnvironment = appEnvironment,
+            mockProject = project,
+            name = "Kotlin stdlib",
+            javaVersion = jvmTarget,
+            roots = listOf(getKotlinJvmStdlibJarPath()),
+        )
+
+
+        val modules = ideaProject.modules.map { module ->
+            val dependencies = module
+                .dependencies
+                .filterIsInstance<IdeaSingleEntryLibraryDependency>()
+                .map { dependency ->
+                    LibraryModule(
+                        appEnvironment = appEnvironment,
+                        mockProject = project,
+                        name = dependency.file.name,
+                        javaVersion = jvmTarget,
+                        roots = listOf(dependency.file.toPath()),
+                    )
+                }
+
+
+            val allDependencies = mutableListOf<KaModule>(kotlinStdlib)
+            if (jdkModule != null) {
+                allDependencies.add(jdkModule)
+            }
+            allDependencies.addAll(dependencies)
+
+            SourceModule(
+                mockProject = project,
+                folderPath = module.contentRoots.first().rootDirectory.path,
+                dependencies = allDependencies,
+                javaVersion = jvmTarget,
+                kotlinVersion = LanguageVersion.KOTLIN_2_1,
+                moduleName = module.name
+            )
+        }
+
+        // TODO Support multiple modules, for now take the last one
+        val rootModule = modules.last()
+        return rootModule to ""
+    }
+}
+
+private fun getJdkHomePathFromSystemProperty(): Path? {
+    val javaHome = File(System.getProperty("java.home"))
+    if (!javaHome.exists()) {
         return null
     }
+    return javaHome.toPath()
+}
+
+internal fun getKotlinJvmStdlibJarPath(): Path {
+    return Path(lazyKotlinJvmStdlibJar)
+}
+
+private val lazyKotlinJvmStdlibJar by lazy {
+    ClassLoader.getSystemResource("kotlin/jvm/Strictfp.class")
+        ?.file
+        ?.replace("file:", "")
+        ?.replaceAfter(".jar", "")
+        ?: error("Unable to find Kotlin's JVM stdlib jar.")
 }

--- a/app/src/main/kotlin/org/kotlinlsp/buildsystem/Resolver.kt
+++ b/app/src/main/kotlin/org/kotlinlsp/buildsystem/Resolver.kt
@@ -13,7 +13,7 @@ class BuildSystemResolver(
 ) {
     private val BUILD_SYSTEMS: List<BuildSystem> = listOf(
         FileBasedBuildSystem(project, appEnvironment, rootFolder),
-        GradleBuildSystem()
+        GradleBuildSystem(project, appEnvironment, rootFolder)
     )
 
     fun resolveModuleDAG(): KaModule = profile("BuildSystemResolver", "") {


### PR DESCRIPTION
Adds initial support for Gradle via [Gradle Tooling](https://docs.gradle.org/current/userguide/tooling_api.html).

It does so by implementing the `GradleBuildSystem` class, letting Gradle Tooling resolve all modules/dependencies, and then map those to the correct `LibraryModule` and `SourceModule`s.

Verified this locally on neovim with no additional configuration required. 