### PR TITLE
Lint all open files

### DIFF
--- a/app/src/main/kotlin/org/kotlinlsp/analysis/AnalysisSession.kt
+++ b/app/src/main/kotlin/org/kotlinlsp/analysis/AnalysisSession.kt
@@ -299,7 +299,7 @@ class AnalysisSession(private val notifier: AnalysisSessionNotifier, rootPath: S
     fun lintFile(path: String) {
         val ktFile = openedFiles[path]!!
         index.queueOnFileChanged(ktFile)
-        updateDiagnostics(ktFile)
+        for (openedKtFile in openedFiles.values) updateDiagnostics(openedKtFile)
     }
 
     fun dispose() {


### PR DESCRIPTION
Just a small contribution to get started!

I believe that when a user modifies a file we should recompute diagnostics for all open files, otherwise some of them might get outdated. I'm using rust-analyzer as a reference and I think it does the same.