### PR TITLE
fix(lsp): add missing name field to `serverInfo`

### DIFF
--- a/app/src/main/kotlin/org/kotlinlsp/lsp/Server.kt
+++ b/app/src/main/kotlin/org/kotlinlsp/lsp/Server.kt
@@ -62,6 +62,7 @@ class KotlinLanguageServer(
             completionProvider = CompletionOptions(false, listOf("."))
         }
         val serverInfo = ServerInfo().apply {
+            name = "kotlin-lsp"
             version = getLspVersion()
         }
 


### PR DESCRIPTION
Required by spec, see
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initializeResult